### PR TITLE
fix: missing (1+qv) factor in calculation of derivative of rho_d when…

### DIFF
--- a/examples/PyMPDATA_examples/Shipway_and_Hill_2012/settings.py
+++ b/examples/PyMPDATA_examples/Shipway_and_Hill_2012/settings.py
@@ -54,7 +54,7 @@ class Settings:
             if not apprx_drhod_dz:  # to resolve issue #335
                 qv = self.qv(z)
                 dqv_dz = Derivative(self.qv)(z)
-                drhod_dz = drhod_dz / (1 + qv) - rhod * dqv_dz / (1 + qv)**2
+                drhod_dz = drhod_dz / (1 + qv) - rhod * dqv_dz / (1 + qv) ** 2
             return drhod_dz
 
         z_points = np.arange(0, self.z_max + self.dz / 2, self.dz / 2)

--- a/examples/PyMPDATA_examples/Shipway_and_Hill_2012/settings.py
+++ b/examples/PyMPDATA_examples/Shipway_and_Hill_2012/settings.py
@@ -54,7 +54,7 @@ class Settings:
             if not apprx_drhod_dz:  # to resolve issue #335
                 qv = self.qv(z)
                 dqv_dz = Derivative(self.qv)(z)
-                drhod_dz = drhod_dz / (1 + qv) - rhod * dqv_dz / (1 + qv)
+                drhod_dz = drhod_dz / (1 + qv) - rhod * dqv_dz / (1 + qv)**2
             return drhod_dz
 
         z_points = np.arange(0, self.z_max + self.dz / 2, self.dz / 2)


### PR DESCRIPTION
… accounting for water vapour

rho_d(z) = rho(z) / (1 + qv(z))
therefore drho_d/dz = drho/dz / (1+ qv) - dqv/dz / (1 + qv)^2
_not(!)_ drho_d/dz = drho/dz / (1+ qv) - dqv/dz / (1 + qv)